### PR TITLE
Use fork of action-sphinx-docs-to-gh-pages to workaround unquoted git commiter name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,6 @@ jobs:
               with:
                   branch: master
                   dir_docs: docs
-                  sphinx-api-opts: "--separate -o . ../"
-                  sphinx-api-exclude: ""
+                  sphinx-apidoc-opts: "--separate -o . ../"
+                  sphinx-apidoc-exclude: ""
                   sphinx-opts: ""


### PR DESCRIPTION
The issue had already been reported and there is a (still) open pull request:
https://github.com/uibcdf/action-sphinx-docs-to-gh-pages/pull/8

Since it hasn't been merged, I tried using the fork with the patch, but it has another syntax error that I fixed in my own fork (for now): https://github.com/aeisenbarth/action-sphinx-docs-to-gh-pages/tree/patch-1

Resolves https://github.com/tdrose/metaspace-converter/issues/3