### PR TITLE
Fixes for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # METASPACE converter
 
+[![Tests][badge-tests]][link-tests]
+[![Documentation][badge-docs]][link-docs]
+[![PyPI][badge-pypi]][link-pypi]
+
 Python package to download and convert datasets from the [METASPACE](https://metaspace2020.eu/)
 knowledge base to common formats for single-cell and spatial omics analysis.
 Datasets can be directly downloaded to
@@ -155,3 +159,10 @@ sdata.points["maldi_points"] = sdata.transform_element_to_coordinate_system(
 ```
 
 ![Image](docs/_static/img/example_img_sd.png)
+
+[badge-docs]: https://img.shields.io/github/actions/workflow/status/metaspace2020/metaspace-converter/docs.yml?label=documentation
+[badge-pypi]: https://img.shields.io/pypi/v/metaspace-converter
+[badge-tests]: https://img.shields.io/github/actions/workflow/status/metaspace2020/metaspace-converter/tests.yml?branch=master&label=tests
+[link-docs]: https://metaspace2020.github.io/metaspace-converter/
+[link-pypi]: https://pypi.org/project/metaspace-converter/
+[link-tests]: https://github.com/metaspace2020/metaspace-converter/actions/workflows/tests.yml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ of spatial omics data. This enables users to easily align and integrate METASPAC
 to other spatial omics modalities.
 
 If you encounter any bugs or have suggestions for new features, please open an issue in the
-[github repository](https://github.com/metaspace2020/metaspace-converter).
+[GitHub repository](https://github.com/metaspace2020/metaspace-converter).
 
 ## Installation
 
@@ -79,7 +79,7 @@ sc.pl.spatial(
 #### Squidpy
 
 Optical images can also be downloaded and save in the object if available.
-Squidpy allows for an easy overlay of ion iamge and optical image.
+Squidpy allows for an easy overlay of ion image and optical image.
 
 ```python
 from metaspace_converter import metaspace_to_anndata
@@ -103,7 +103,7 @@ sq.pl.spatial_scatter(
 #### Convert AnnData objects to ion image arrays
 
 If you want to work with the ion images as numpy arrays, the function `anndata_to_image_array` can
-convert previoysly workloaded AnnData objects to numpy arrays.
+convert previously downloaded AnnData objects to numpy arrays.
 
 ```python
 from metaspace_converter import metaspace_to_anndata, anndata_to_image_array

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -89,3 +89,6 @@ Here using a reversed colormap which better represents intense values on bright 
    :hide:
 
    ...
+
+.. image:: ./_static/img/example_img_sd.png
+   :alt: Visualization with SpatialData

--- a/metaspace_converter/to_spatialdata.py
+++ b/metaspace_converter/to_spatialdata.py
@@ -110,7 +110,7 @@ def metaspace_to_spatialdata(
 
     # Create points
     if add_points:
-        points = _create_points(dataset, adata, name=points_name_added)
+        points = _create_points(dataset, adata)
         sdata.points[points_name_added] = points
 
     return sdata
@@ -183,7 +183,7 @@ def _create_spatialdata_table(adata: AnnData) -> AnnData:
     )
 
 
-def _create_points(dataset: SMDataset, adata: AnnData, name: str = POINTS_KEY) -> pd.DataFrame:
+def _create_points(dataset: SMDataset, adata: AnnData) -> pd.DataFrame:
     # FIXME: PointsModel does not yet allow to specify units, we should set micrometers as in image.
     # FIXME: Workaround for that napari-spatialdata does not allow to visualize values from ``X``
     #  array, only from ``obs``. For now, we copy X to ``obs`` to enable visualization.


### PR DESCRIPTION
This PR contains fixes for the documentation pages:

- The third, missing image in https://metaspace2020.github.io/metaspace-converter/examples.html
- Badges for tests status, documentation and PyPI package
- typos