### PR TITLE
Update uibcdf/action-sphinx-docs-to-gh-pages and remove workaround

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,7 @@ jobs:
               run: |
                 python -m pip install -vv --no-build-isolation .
             - name: Running the Sphinx to gh-pages Action
-              # uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.0.0
-              # Workaround for bug about improper quoting of GitHub usernames with spaces:
-              # https://github.com/uibcdf/action-sphinx-docs-to-gh-pages/pull/8
-              uses: aeisenbarth/action-sphinx-docs-to-gh-pages@patch-1
+              uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.1.0
               with:
                   branch: master
                   dir_docs: docs


### PR DESCRIPTION
The GitHub action that we use to build documentation has been updated.
We don't need our fork anymore to solve the issue with spaces in user display names.

https://github.com/uibcdf/action-sphinx-docs-to-gh-pages/pull/8#issuecomment-1906992729
