### PR TITLE
Fix coloc docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,3 +8,11 @@ metaspace_converter
    :members:
    :undoc-members:
    :show-inheritance:
+
+metaspace_converter.colocalization
+----------------------------------
+
+.. automodule:: metaspace_converter.colocalization
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/metaspace_converter/colocalization.py
+++ b/metaspace_converter/colocalization.py
@@ -20,9 +20,10 @@ def coloc_ml_preprocessing(
 
     In the publication, the authors evaluated colocalization metrics and preprocessing approaches.
     They found the best performance for
-    1) median filtering of ion images with a (3, 3) kernel size and
-    2) quantile thresholding at 50%, meaning all pixels with intensities below the 50%
-    quantile set to 0.
+
+    1. median filtering of ion images with a (3, 3) kernel size and
+    2. quantile thresholding at 50%, meaning all pixels with intensities below the 50%
+       quantile set to 0.
 
     This function performs the same preprocessing steps.
     Recommended for call before running the ``colocalization`` function.

--- a/metaspace_converter/colocalization.py
+++ b/metaspace_converter/colocalization.py
@@ -18,10 +18,10 @@ def coloc_ml_preprocessing(
     Preprocessing for colocalization analysis according to the colocML publication
     (https://doi.org/10.1093/bioinformatics/btaa085).
 
-    In the publication the authors evaluated colocalization metrics and preprocessing approaches.
+    In the publication, the authors evaluated colocalization metrics and preprocessing approaches.
     They found the best performance for
     1) median filtering of ion images with a (3, 3) kernel size and
-    2) quantile thresholding ad 50%, meaning all pixels with intensities below the 50%
+    2) quantile thresholding at 50%, meaning all pixels with intensities below the 50%
     quantile set to 0.
 
     This function performs the same preprocessing steps.
@@ -76,7 +76,7 @@ def colocalization(adata: AnnData, layer: Optional[str] = "coloc_ml_preprocessin
     In combination with the ``colocML_preprocessing`` function, this metric performed best in the
     colocML publication (https://doi.org/10.1093/bioinformatics/btaa085).
 
-    It is recommended to call the the ``coloc_ml_preprocessing`` function beforehand.
+    It is recommended to call the ``coloc_ml_preprocessing`` function beforehand.
 
     Args:
         adata: An AnnData object.


### PR DESCRIPTION
The colocalization was not included in documentation.

This was because we have Sphinx set up to document only explicitly (discovery with `sphinx-apidoc` often gives unwanted results). [`automodule`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-automodule) has an option `:imported-members:` but it only includes directly imported functions, not modules.

So I added a separate, explicit section for the colocalization module.

Closes #19